### PR TITLE
Add reaction config

### DIFF
--- a/configs/problem/activity_recognition_reaction_ond_config.yaml
+++ b/configs/problem/activity_recognition_reaction_ond_config.yaml
@@ -1,0 +1,93 @@
+# @package _group_
+protocol: 'ond'
+workdir: ''
+harness: 'local'
+domain: activity_recognition
+test_ids:
+  - OND.0.90001.2100554
+dataset_root: ""
+detectors:
+  has_baseline: 'False'
+  has_reaction_baseline: 'True'
+  baseline_class: 'baseline_i3d'
+  csv_folder: activity_recognition
+  cores: 6
+  detection_threshold: 0.1
+  detector_configs:
+    baseline_i3d:
+      feature_extractor_params:
+        backbone_weight_path: ''
+        name: i3d
+        arch: i3d-50
+        model_name: i3d
+        n_classes: 88
+        no_cuda: 'False'
+        hidden_dims:
+          - 512
+          - 128
+        hidden: 'True'
+        in_dim: 1024
+        num_heads:
+          - 4
+          - 1
+        sample_duration: 64
+        mode: score
+        graph_classes: 88
+        feature_type: graph
+      dataloader_params:
+        sample_size: 224
+        mean:
+          - 114.7748
+          - 107.7354
+          - 99.475
+        sample_duration: 64
+        batch_size: 1
+        n_threads: 6
+        n_classes: 88
+    gae_kl_nd:
+      feature_extractor_params:
+        backbone_weight_path: ''
+        name: i3d
+        arch: i3d-50
+        graph_weight_path: ''
+        model_name: i3d
+        n_classes: 400
+        no_cuda: 'False'
+        hidden_dims:
+          - 512
+          - 128
+        hidden: 'True'
+        in_dim: 1024
+        num_heads:
+          - 4
+          - 1
+        sample_duration: 64
+        mode: feature
+        graph_classes: 88
+        feature_type: graph
+      kl_params:
+        window_size: 100
+        mu_train: 1.0
+        sigma_train: 0.1242729408792351
+        KL_threshold: 5.365822113508410
+      evm_params:
+        weight_path:  ''
+        number_of_unknown_to_crate_evm: 7
+      characterization_params:
+        clustering_type: FINCH
+        number_of_unknown_to_strat_clustering: 50
+      dataloader_params:
+        sample_size: 224
+        mean:
+          - 114.7748
+          - 107.7354
+          - 99.475
+        sample_duration: 64
+        batch_size: 1
+        n_threads: 6
+        n_classes: 88
+harness_config:
+  url: 'http://3.32.8.161:5001/'
+  data_dir: ''
+  gt_dir: ''
+  gt_config: ''

--- a/configs/problem/hwr_nd_reaction.yaml
+++ b/configs/problem/hwr_nd_reaction.yaml
@@ -1,0 +1,35 @@
+# @package _group_
+protocol: 'ond'
+workdir: ''
+harness: 'local'
+domain: transcripts
+dataset_root: ''
+test_ids:
+- OND.0.90001.8714062
+detectors:
+  has_reaction_baseline: True
+  has_baseline: False
+  csv_folder: "writer_identifier"
+  baseline_class: "BaselineWriterIdentifier"
+  detector_configs:
+    HWRNoveltyDetector:
+      config_file_path: ""
+      cores: 1
+      device: gpu
+      img_height: 64
+      hogs_ppc: 16
+      unknown_threshold: 0.5
+      crnn_pass: []
+      save_header_csv: 0
+    BaselineWriterIdentifier:
+      checkpoint_path: ""
+      crop_size: 113
+      batch_size: 32
+      num_workers: 1
+      num_classes: 50
+      use_gpu: False
+harness_config:
+  url: 'http://3.32.8.161:5001/'
+  data_dir: ''
+  gt_dir: ''
+  gt_config: ''

--- a/configs/problem/image_classification_reaction_ond_config.yaml
+++ b/configs/problem/image_classification_reaction_ond_config.yaml
@@ -1,0 +1,60 @@
+# @package _group_
+protocol: 'ond'
+workdir: ''
+harness: 'local'
+domain: "image_classification"
+test_ids:
+- "OND.54011215.0000.1236"
+hints:
+- "red_light"
+use_feedback: True
+dataset_root: ""
+detectors:
+  has_reaction_baseline: True
+  has_baseline: False
+  csv_folder: image_classification
+  baseline_class: "BaselineImageClassifier"
+  detector_configs:
+    BaselineImageClassifier:
+      model_name: "resnet50"
+      checkpoint_path: ""
+      image_size: 256
+      crop_size: 224
+      batch_size: 100
+      num_workers: 6
+      num_classes: 413
+      use_gpu: True
+    OND_12_With_Redlight:
+      efficientnet_params:
+          model_path: ""
+          known_classes: 413
+          image_size: 300
+      evm_params:
+          model_path: ""
+          tailsize: 40000
+          cover_threshold: 0.7
+          distance_multiplier: 0.55
+          distance_function: "cosine"
+          mu_train: 1.0
+          sigma_train: 0.1872130436656377
+          KL_threshold: 7.13040406025555
+          known_threshold: 0.7
+      dataloader_params:
+          batch_size: 100
+          num_workers: 20
+      feedback_params:
+          first_budget: 10
+          income_per_batch: 10
+          maximum_budget: 10
+      classification_params:
+          alpha: 1.0
+          flag_only_evm: 1
+  save_elementwise: False
+  save_attributes: False
+  use_saved_attributes: False
+save_dir: "{workdir.id}"
+harness_config:
+  url: 'http://3.32.8.161:5001/'
+  data_dir: ''
+  gt_dir: ''
+  gt_config: ''


### PR DESCRIPTION
This PR adds configs that are used for computing reaction performance in the 3 domains. Depends on https://github.com/darpa-sail-on/sail-on-client/pull/83 and https://github.com/darpa-sail-on/sail-on-client/pull/84